### PR TITLE
Working Cancel Buttons in Time Off Request Windows

### DIFF
--- a/src/gui/TimeOffRequestBuilder.java
+++ b/src/gui/TimeOffRequestBuilder.java
@@ -309,15 +309,29 @@ public class TimeOffRequestBuilder {
 		Shift sh=new Shift(from, to.compareTo(from));
 		
 		req= new TimeOffRequest(sh, (int)prioritySlider.getValue());
+		
+		System.out.println("save pressed");
+		Stage stage = (Stage) cancelButton.getScene().getWindow();
+	    stage.close();
 
 	}
 	public void actionCancel(ActionEvent event) {
 		req=null;
 
-		close(event);
+		System.out.println("cancel pressed");
+		Stage stage = (Stage) cancelButton.getScene().getWindow();
+	    stage.close();
+	    
+		
+		
+		
 	}
-	public void quit(ActionEvent event) {actionCancel(event);}
+	public void quit(ActionEvent event) {actionCancel(event);
+		
+	}
 	public void close(ActionEvent event) {
-
+		System.out.println("close pressed");
+		Stage stage = (Stage) cancelButton.getScene().getWindow();
+	    stage.close();
 	}
 }

--- a/src/gui/TimeOffRequestWindow.java
+++ b/src/gui/TimeOffRequestWindow.java
@@ -43,7 +43,11 @@ public class TimeOffRequestWindow {
 	}
 
 	public void actionCloseTimeOffWindow(ActionEvent event) {
+		// write saving solution here
 		
+		System.out.println("close pressed");
+		Stage stage = (Stage) closeButton.getScene().getWindow();
+	    stage.close();
 	}
 	
 	public void actionAddRequest(ActionEvent event) {
@@ -64,10 +68,14 @@ public class TimeOffRequestWindow {
 			System.out.println("before show");
 			
 			st.showAndWait();
-			System.out.println("after show");
+			System.out.println("after show request");
 			
-			tor.add(TimeOffRequestBuilder.req);
-			RequestBox.getItems().add(TimeOffRequestBuilder.req.toString());
+			
+			if (TimeOffRequestBuilder.req != null) {
+				tor.add(TimeOffRequestBuilder.req);
+				RequestBox.getItems().add(TimeOffRequestBuilder.req.toString());
+			}
+			
 			
 		}catch(Exception e) {
 			System.out.println("ERROR SHOWING "+e.toString());


### PR DESCRIPTION
Implemented cancel buttons in both time off request builder and main time off request window, also fixed nullpointerexception when time off request builder is closed without a valid time off request